### PR TITLE
Fix TypeError

### DIFF
--- a/src-py/pyrickroll.py
+++ b/src-py/pyrickroll.py
@@ -204,7 +204,8 @@ class TranslateToPython:
 
         # if this line doesn't have code, then write "\n"
         else:
-            error()
+            pass
+            #error()
 
             
     def convert(self, kw):


### PR DESCRIPTION
I try to run the examples but I got:
TypeError: error() missing 1 require positional argument: 'error_msg'
Now the examples can work without error!