### PR TITLE
Add MacOS support for c++

### DIFF
--- a/src/crickroll.py
+++ b/src/crickroll.py
@@ -286,5 +286,9 @@ def run_in_cpp(src_file_name: str):
         exe_file = f'{f_name}.out'
         system(f'g++ {f_name}.cpp -o {exe_file}')
         system(f'./{exe_file}')
+    elif platform == 'darwin':
+        exe_file = f'{f_name}.out'
+        system(f'g++ {f_name}.cpp -o {exe_file}')
+        system(f'./{exe_file}')
     else:
         raise NotImplementedError(f"Platform {platform} is not supported")


### PR DESCRIPTION
I'm pretty sure gcc is pre installed on macos, but if it isn't it should prompt the user to install xcode tools.
So it should just be the same command as linux to compile it.