### PR TITLE
fix "\n" conversion in `filter_str`

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -35,16 +35,7 @@ def filter_str(s:str):
     Remove 1st and last chars, and
     replace line-feed literals with actual line-feeds.
     """
-    res = ""
-    i = 1
-    while i < len(s) - 1:
-        if s[i] == '\\' and s[i + 1] == 'n':
-            res += '\n'
-            i += 2
-        else:
-            res += s[i]
-        i += 1
-    return res
+    return s[1:-1].replace("\\n", "\n")
 
 def precedence(op: str):
     """

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -31,21 +31,20 @@ def remove_all(l: list, x):
     return l
 
 def filter_str(s:str):
+    """
+    Remove 1st and last chars, and
+    replace line-feed literals with actual line-feeds.
+    """
     res = ""
     i = 1
     while i < len(s) - 1:
-        if s[i] == '\\':
-            if s[i + 1] == 'n':
-                res += '\n'
-                i += 1
+        if s[i] == '\\' and s[i + 1] == 'n':
+            res += '\n'
+            i += 2
         else:
             res += s[i]
         i += 1
     return res
-
-# filter_str: Final[Callable[[str], str]] = lambda s: s[1:-1]
-"""Remove 1st and last chars from a `str`."""
-
 
 def precedence(op: str):
     """


### PR DESCRIPTION
I noticed an off-by-one error when iterating, which (I expect) would convert this:
```
"rick\nroll"
```
into this
```
rick
nroll
```
I haven't ran any tests, I just debugged it in my mind.

This is a draft, because I want to know if this was intentional, and bc I'll replace the code by a slice-&-replace, which is less bug-prone