### PR TITLE
fix errors when execute play_audio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyttsx3
-playsound
+playsound==1.2.2
 argparse

--- a/src/AudioGenerator.py
+++ b/src/AudioGenerator.py
@@ -30,7 +30,7 @@ if dependancyMissingBool:
             system("pip install pyttsx3")
         if playsoundMissingBool:
             print("Installing the pip package playsound...")
-            system("pip install playsound")
+            system("pip install playsound==1.2.2")
         try:
             from pyttsx3 import init
         except:

--- a/src/RickRoll.py
+++ b/src/RickRoll.py
@@ -13,15 +13,15 @@ import interpreter
 
 def play_audio(src_file_name: str):
     import AudioGenerator
-    from pyrickroll import Token
-    from Lexer import lexicalize
+    from crickroll import Token
+    from Lexer import tokenize
 
     with open(src_file_name, mode='r', encoding='utf-8') as src:
         content = src.readlines()
         if len(content) > 0:
             content[-1] += '\n'
         for statement in content:
-            tokens = lexicalize(statement)
+            tokens = tokenize(statement)
             tok = Token(tokens)
 
             for v in tok.t_values:


### PR DESCRIPTION
As a Windows user, I encountered several errors when running the following command:
```sh
python RickRoll.py ..\examples\HelloWorld.rickroll --audio
```

### Errors:
**1.  Import Errors in `play_audio` Function:**

```
File "E:\Projects\rickroll-lang\src\RickRoll.py", line 16, in play_audio
    from pyrickroll import Token
ImportError: cannot import name 'Token' from 'pyrickroll' (E:\Projects\rickroll-lang\src\pyrickroll.py)
```

```
File "E:\Projects\rickroll-lang\src\RickRoll.py", line 17, in play_audio
    from Lexer import lexicalize
ImportError: cannot import name 'lexicalize' from 'Lexer' (E:\Projects\rickroll-lang\src\Lexer.py)
```
These errors were due to incorrect import names in the play_audio function. I have corrected them.
<br>

**2. `playsound` Error:**
```
File "E:\Projects\rickroll-lang\src\AudioGenerator.py", line 67, in play
    play_wav(au)
File "D:\ProgramData\anaconda3\envs\playground\Lib\site-packages\playsound.py", line 72, in _playsoundWin
    winCommand(u'open {}'.format(sound))
File "D:\ProgramData\anaconda3\envs\playground\Lib\site-packages\playsound.py", line 64, in winCommand
    raise PlaysoundException(exceptionMessage)
playsound. PlaysoundException:
    Error 263 for command:
        open audios/main.wav
    The specified device is not open or is not recognized by MCI.
```
This issue appears to be related to playsound, as noted in [this issue](https://github.com/TaylorSMarks/playsound/issues/140). Downgrading playsound to version 1.2.2 resolved the problem for me. Given that the last commit to playsound was four years ago, I have locked the dependency version to ensure stability.

Feel free to modify any code you think needs improvement! 